### PR TITLE
Fix file encoding detect issue

### DIFF
--- a/text/replacer.py
+++ b/text/replacer.py
@@ -68,11 +68,12 @@ class TextReplacer:
     def replace_words(self):
         try:
             encoding = self.detect_encoding()
+            encoding = 'utf-8' if encoding == None else encoding
         except Exception as e:
             encoding = 'utf-8'
         try:
             with codecs.open(self.output_file, 'w', encoding='utf-8', errors='ignore') as output:
-                with codecs.open(self.input_file, 'r', encoding=encoding, errors='replace') as input:
+                with codecs.open(self.input_file, 'r', encoding=encoding, errors='surrogateescape') as input:
                     content = input.read()
                     for old_word, new_word in self.rule_list.items():
                         content = content.replace(old_word, new_word)

--- a/ui/tabs/text_replacer_tab.py
+++ b/ui/tabs/text_replacer_tab.py
@@ -18,8 +18,10 @@ class tkTextReplacerTab(tkTabFrame):
         input_file = self.inputFileSelectItem.entry.get("1.0", tk.END).splitlines()[0]
         output_file = self.outPutFileSelectItem.entry.get("1.0", tk.END).splitlines()[0]
         rule_list_file = self.ruleListFileSelectItem.entry.get("1.0", tk.END).splitlines()[0]
-
-        self.replacer.update_files(input_file, output_file, rule_list_file)
-        self.replacer.load_rule_list()
-        self.replacer.replace_words()
-        tk.messagebox.showinfo("完成提示", "替换完成。请查看输出文件: {}".format(output_file))
+        try:
+            self.replacer.update_files(input_file, output_file, rule_list_file)
+            self.replacer.load_rule_list()
+            self.replacer.replace_words()
+            tk.messagebox.showinfo("完成提示", "替换完成🆗。😼请查看输出文件: {}".format(output_file))
+        except Exception as e:
+            tk.messagebox.showerror("错误提示", f"替换失败🆖, 😹错误信息: {str(e)}")


### PR DESCRIPTION
1. If file encoding detection failed, use "utf-8" to open file.
2. Catch the exception of replacing and raise to message box.